### PR TITLE
translation tooltip in costume editor

### DIFF
--- a/editor/paint-editor/en.json
+++ b/editor/paint-editor/en.json
@@ -41,5 +41,8 @@
     "paint.roundedRectMode.roundedRect": "Rounded Rectangle",
     "paint.selectMode.select": "Select",
     "paint.textMode.text": "Text",
-    "paint.colorPicker.swap": "Swap"
+    "paint.colorPicker.swap": "Swap",
+    "paint.rectMode.triangle": "Triangle",
+    "paint.rectMode.arrow": "Arrow",
+    "paint.rectMode.curve": "Curve"
 }

--- a/editor/paint-editor/es.json
+++ b/editor/paint-editor/es.json
@@ -41,5 +41,8 @@
     "paint.roundedRectMode.roundedRect": "Rectángulo con bordes redoneados",
     "paint.selectMode.select": "Seleccionar",
     "paint.textMode.text": "Texto",
-    "paint.colorPicker.swap": "Invertir"
+    "paint.colorPicker.swap": "Invertir",
+    "paint.rectMode.triangle": "Triángulo",
+    "paint.rectMode.arrow": "Flecha",
+    "paint.rectMode.curve": "Curva"
 }

--- a/editor/paint-editor/fr.json
+++ b/editor/paint-editor/fr.json
@@ -41,5 +41,8 @@
     "paint.roundedRectMode.roundedRect": "Rectangle arrondi",
     "paint.selectMode.select": "Sélectionner",
     "paint.textMode.text": "Texte",
-    "paint.colorPicker.swap": "Inverser"
+    "paint.colorPicker.swap": "Inverser",
+    "paint.rectMode.triangle": "Triangle",
+    "paint.rectMode.arrow": "Flèche",
+    "paint.rectMode.curve": "Courbe"
 }

--- a/editor/paint-editor/zh-cn.json
+++ b/editor/paint-editor/zh-cn.json
@@ -41,5 +41,8 @@
     "paint.roundedRectMode.roundedRect": "圆角矩形",
     "paint.selectMode.select": "选择",
     "paint.textMode.text": "文本",
-    "paint.colorPicker.swap": "交换"
+    "paint.colorPicker.swap": "交换",
+    "paint.rectMode.triangle": "三角形",
+    "paint.rectMode.arrow": "箭头",
+    "paint.rectMode.curve": "曲线"
 }

--- a/editor/paint-editor/zh-tw.json
+++ b/editor/paint-editor/zh-tw.json
@@ -41,5 +41,8 @@
     "paint.roundedRectMode.roundedRect": "圓角方形",
     "paint.selectMode.select": "選取",
     "paint.textMode.text": "文字",
-    "paint.colorPicker.swap": "交換"
+    "paint.colorPicker.swap": "交換",
+    "paint.rectMode.triangle": "三角形",
+    "paint.rectMode.arrow": "箭頭",
+    "paint.rectMode.curve": "曲線"
 }


### PR DESCRIPTION
### Resolves

[#953](https://trello.com/c/tXJFHEr9/953-fix-the-tooltip-for-the-3-new-buttons-in-costume-editor)

### Description:

-  Translation the tooltip for the 3 new buttons in costume editor

### Result : 
<img width="214" alt="Screen Shot 2021-10-12 at 15 54 05" src="https://user-images.githubusercontent.com/81544374/136924530-8a7865fa-7e54-4d8e-bc6b-9fb75841fa1a.png">
<img width="191" alt="Screen Shot 2021-10-12 at 15 54 11" src="https://user-images.githubusercontent.com/81544374/136924546-dab3391b-08e6-4a64-829a-23cd0d5698b4.png">
<img width="158" alt="Screen Shot 2021-10-12 at 15 54 16" src="https://user-images.githubusercontent.com/81544374/136924555-de068133-a1c6-4727-a83b-d923c15668fa.png">

