### PR TITLE
Add locale for full screen button in paint editor

### DIFF
--- a/editor/paint-editor/en.json
+++ b/editor/paint-editor/en.json
@@ -16,6 +16,7 @@
     "paint.paintEditor.front": "Front",
     "paint.paintEditor.back": "Back",
     "paint.paintEditor.more": "More",
+    "paint.paintEditor.fullscreenControl": "Full Screen Control",
     "paint.modeTools.brushSize": "Size",
     "paint.modeTools.eraserSize": "Eraser size",
     "paint.modeTools.copy": "Copy",

--- a/editor/paint-editor/es.json
+++ b/editor/paint-editor/es.json
@@ -16,6 +16,7 @@
     "paint.paintEditor.front": "Al frente",
     "paint.paintEditor.back": "Al fondo",
     "paint.paintEditor.more": "Más",
+    "paint.paintEditor.fullscreenControl": "Control de pantalla completa",
     "paint.modeTools.brushSize": "Tamaño",
     "paint.modeTools.eraserSize": "Tamaño de la goma",
     "paint.modeTools.copy": "Copiar",

--- a/editor/paint-editor/fr.json
+++ b/editor/paint-editor/fr.json
@@ -16,6 +16,7 @@
     "paint.paintEditor.front": "Avant-plan",
     "paint.paintEditor.back": "Arrière-plan",
     "paint.paintEditor.more": "Plus",
+    "paint.paintEditor.fullscreenControl": "Contrôle plein écran",
     "paint.modeTools.brushSize": "Taille",
     "paint.modeTools.eraserSize": "Taille de la gomme",
     "paint.modeTools.copy": "Copier",

--- a/editor/paint-editor/zh-cn.json
+++ b/editor/paint-editor/zh-cn.json
@@ -16,6 +16,7 @@
     "paint.paintEditor.front": "放最前面",
     "paint.paintEditor.back": "放最后面",
     "paint.paintEditor.more": "更多",
+    "paint.paintEditor.fullscreenControl": "全屏控制",
     "paint.modeTools.brushSize": "粗细",
     "paint.modeTools.eraserSize": "橡皮擦大小",
     "paint.modeTools.copy": "复制",

--- a/editor/paint-editor/zh-tw.json
+++ b/editor/paint-editor/zh-tw.json
@@ -16,6 +16,7 @@
     "paint.paintEditor.front": "移到最上層",
     "paint.paintEditor.back": "移到最下層",
     "paint.paintEditor.more": "更多",
+    "paint.paintEditor.fullscreenControl": "全屏控制",
     "paint.modeTools.brushSize": "尺寸",
     "paint.modeTools.eraserSize": "擦子寬度",
     "paint.modeTools.copy": "複製",


### PR DESCRIPTION
**- Ref** : https://trello.com/c/RKNqsFC1

**- Description** : on the top right of the costume editor, add a button to go full screen or exit full screen. when in full screen, we do not show the costume list on left, or the stage/sprite pane on right, or the backpack at bottom. Then the editor can be much bigger. from 480x360 -> 800x600

**- Result** :

https://user-images.githubusercontent.com/86275790/145935848-2ba0562e-8e86-4d71-aaa2-ad8030ac540b.mp4


