### PR TITLE
Hotfix - input placeholder of help modal

### DIFF
--- a/editor/interface/en.json
+++ b/editor/interface/en.json
@@ -162,7 +162,7 @@
     "gui.menuBar.publishButtonMessage": "Publish your project without sharing your code blocks",
     "gui.menuBar.publishToFriendsButtonMessage": "Publish your project to your friends only",
     "gui.menuBar.helpButton": "Help",
-    "gui.menuBar.helpInputPlaceholder": "Type a question",
+    "gui.menuBar.helpInputPlaceholder": "Type here",
     "gui.menuBar.helpButtonSend": "Send",
     "gui.blockSearch.placeholder": "Search block",
     "gui.blockSearchWorkspace.placeholder": "Search workspace block",

--- a/editor/interface/es.json
+++ b/editor/interface/es.json
@@ -162,7 +162,7 @@
     "gui.menuBar.publishButtonMessage": "Publique su proyecto sin compartir sus bloques de código",
     "gui.menuBar.publishToFriendsButtonMessage": "Publica tu proyecto solo para tus amigos",
     "gui.menuBar.helpButton": "Ayuda",
-    "gui.menuBar.helpInputPlaceholder": "Escriba una pregunta",
+    "gui.menuBar.helpInputPlaceholder": "Escriba aquí",
     "gui.menuBar.helpButtonSend": "Enviar",
     "gui.blockSearch.placeholder": "Bloque de búsqueda",
     "gui.blockSearchWorkspace.placeholder": "Bloque de espacio de trabajo de búsqueda",

--- a/editor/interface/fr.json
+++ b/editor/interface/fr.json
@@ -162,7 +162,7 @@
     "gui.menuBar.publishButtonMessage": "Publiez votre projet sans partager vos blocs de code",
     "gui.menuBar.publishToFriendsButtonMessage": "Publiez votre projet à vos amis uniquement",
     "gui.menuBar.helpButton": "Aider",
-    "gui.menuBar.helpInputPlaceholder": "Tapez une question",
+    "gui.menuBar.helpInputPlaceholder": "Écrivez ici",
     "gui.menuBar.helpButtonSend": "Envoyer",
     "gui.blockSearch.placeholder": "Bloc de recherche",
     "gui.blockSearchWorkspace.placeholder": "Rechercher dans le bloc de l'espace de travail",

--- a/editor/interface/zh-cn.json
+++ b/editor/interface/zh-cn.json
@@ -162,7 +162,7 @@
     "gui.menuBar.publishButtonMessage": "在不共享代码块的情况下发布您的项目",
     "gui.menuBar.publishToFriendsButtonMessage": "仅将您的项目发布给您的朋友",
     "gui.menuBar.helpButton": "帮助",
-    "gui.menuBar.helpInputPlaceholder": "输入问题",
+    "gui.menuBar.helpInputPlaceholder": "在此输入",
     "gui.menuBar.helpButtonSend": "发送",
     "gui.blockSearch.placeholder": "搜索积木块",
     "gui.blockSearchWorkspace.placeholder": "搜索工作区",

--- a/editor/interface/zh-tw.json
+++ b/editor/interface/zh-tw.json
@@ -151,7 +151,7 @@
     "gui.menuBar.publishToFriendsButtonMessage": "僅將您的項目發布給您的朋友",
     "gui.menuBar.shareWithPasswordPlaceholder": "輸入密碼",
     "gui.menuBar.helpButton": "幫助",
-    "gui.menuBar.helpInputPlaceholder": "輸入問題",
+    "gui.menuBar.helpInputPlaceholder": "在此輸入",
     "gui.menuBar.helpButtonSend": "發送",
     "gui.menuBar.logoTile": "CCLogoWhiteCH3.png",
     "gui.menuBar.logo": "CCLogoCH3.png",


### PR DESCRIPTION
**Resolve**: https://trello.com/c/Cy8P7wms

**Description** 
- the width is 520px. can you make it wider? like 1000px? for both the enduser and the admin panel 
-  for the input box, instead of "Type a question", please just do "Type here". 

**Result**

![image](https://user-images.githubusercontent.com/86275790/159203535-9096f4b0-a714-48fe-ad9c-bc05681df2d5.png)


![image](https://user-images.githubusercontent.com/86275790/159204749-ac544c8a-83bb-4f7e-9da0-3b7b370fbb65.png)
