### PR TITLE
Enhance remote editing

### DIFF
--- a/editor/interface/en.json
+++ b/editor/interface/en.json
@@ -634,12 +634,16 @@
     "gui.prompt.numberType": "Number",
     "gui.prompt.dateType": "Date",
     "gui.prompt.stringType": "Text",
-    "gui.remote.start": "Start",
+    "gui.remote.accept": "Accept",
     "gui.remote.status.preparing": "Waiting for the project owner accept..",
     "gui.remote.status.verifying": "Verifying project data..",
     "gui.remote.tracking.unknown": "Unknown",
     "gui.remote.tracking.remoteSession": "Remote Session",
     "gui.remote.tracking.endSession": "End Session",
     "gui.remote.tracking.editWorkspace": "Edit workspace",
-    "gui.remote.tracking.editTarget": "Edit target"
+    "gui.remote.tracking.editTarget": "Edit target",
+    "gui.remote.cancel": "Cancel",
+    "gui.remote.deny": "Deny",
+    "gui.remote.requestToEdit": "Request to Edit",
+    "gui.remote.isRequesting": "is requesting to edit"
 }

--- a/editor/interface/es.json
+++ b/editor/interface/es.json
@@ -636,12 +636,16 @@
     "gui.prompt.numberType": "Número",
     "gui.prompt.dateType": "Fecha",
     "gui.prompt.stringType": "Texto",
-    "gui.remote.start": "comienzo",
+    "gui.remote.accept": "Aceptar",
     "gui.remote.status.preparing": "Esperando a que la dueña del proyecto acepte ..",
     "gui.remote.status.verifying": "Verificando datos del proyecto..",
     "gui.remote.tracking.unknown": "Desconocida",
     "gui.remote.tracking.remoteSession": "Sesión remota",
     "gui.remote.tracking.endSession": "Finalizar sesión",
     "gui.remote.tracking.editWorkspace": "Editar espacio de trabajo",
-    "gui.remote.tracking.editTarget": "Editar objetivo"
+    "gui.remote.tracking.editTarget": "Editar objetivo",
+    "gui.remote.cancel": "Cancelar",
+    "gui.remote.deny": "Negar",
+    "gui.remote.requestToEdit": "Solicitud de edición",
+    "gui.remote.isRequesting": "está solicitando editar"
 }

--- a/editor/interface/fr.json
+++ b/editor/interface/fr.json
@@ -634,12 +634,16 @@
     "gui.prompt.numberType": "Numéro",
     "gui.prompt.dateType": "Date",
     "gui.prompt.stringType": "Texte",
-    "gui.remote.start": "Commencer",
+    "gui.remote.accept": "Accepter",
     "gui.remote.status.preparing": "En attendant que le porteur de projet accepte..",
     "gui.remote.status.verifying": "Vérification des données du projet..",
     "gui.remote.tracking.unknown": "Inconnue",
     "gui.remote.tracking.remoteSession": "Séance à distance",
     "gui.remote.tracking.endSession": "Terminer la session",
     "gui.remote.tracking.editWorkspace": "Modifier l'espace de travail",
-    "gui.remote.tracking.editTarget": "Modifier la cible"
+    "gui.remote.tracking.editTarget": "Modifier la cible",
+    "gui.remote.cancel": "Annuler",
+    "gui.remote.deny": "Refuser",
+    "gui.remote.requestToEdit": "Demande de modification",
+    "gui.remote.isRequesting": "demande à modifier"
 }

--- a/editor/interface/zh-cn.json
+++ b/editor/interface/zh-cn.json
@@ -634,12 +634,16 @@
     "gui.prompt.numberType": "数字",
     "gui.prompt.dateType": "日期",
     "gui.prompt.stringType": "文本",
-    "gui.remote.start": "开始",
+    "gui.remote.accept": "接受",
     "gui.remote.status.preparing": "等待项目业主接受..",
     "gui.remote.status.verifying": "验证项目数据..",
     "gui.remote.tracking.unknown": "未知",
     "gui.remote.tracking.remoteSession": "远程会话",
     "gui.remote.tracking.endSession": "结束会话",
     "gui.remote.tracking.editWorkspace": "编辑工作区",
-    "gui.remote.tracking.editTarget": "编辑目标"
+    "gui.remote.tracking.editTarget": "编辑目标",
+    "gui.remote.cancel": "取消",
+    "gui.remote.deny": "否定",
+    "gui.remote.requestToEdit": "请求编辑",
+    "gui.remote.isRequesting": "正在请求编辑"
 }

--- a/editor/interface/zh-tw.json
+++ b/editor/interface/zh-tw.json
@@ -630,12 +630,16 @@
     "gui.prompt.numberType": "數字",
     "gui.prompt.dateType": "日期",
     "gui.prompt.stringType": "文本",
-    "gui.remote.start": "開始",
+    "gui.remote.accept": "接受",
     "gui.remote.status.preparing": "等待項目業主接受..",
     "gui.remote.status.verifying": "驗證項目數據..",
     "gui.remote.tracking.unknown": "未知",
     "gui.remote.tracking.remoteSession": "远程会话",
     "gui.remote.tracking.endSession": "结束会话",
     "gui.remote.tracking.editWorkspace": "编辑工作区",
-    "gui.remote.tracking.editTarget": "编辑目标"
+    "gui.remote.tracking.editTarget": "编辑目标",
+    "gui.remote.cancel": "取消",
+    "gui.remote.deny": "否定",
+    "gui.remote.requestToEdit": "請求編輯",
+    "gui.remote.isRequesting": "正在請求編輯"
 }


### PR DESCRIPTION
### Resolves

- Resolves #https://trello.com/c/IUZP8Ywy/1006-big-remote-editing-of-playground-premium-only

### Proposed Changes

_Describe what this Pull Request does_

## Checklist for updating translations

There are two situations in which we create manual PRs to update translations:

1. We don't want to wait for Travis's automatic weekly update; or,
2. We need to add a language that has become ready

### 1. Updating translations manually

* [ ] Pull editor translations from Transifex with `> npm run pull:editor`
* [ ] Pull www translations from Transifex with `> npm run pull:www`
* [ ] Test the result with `> npm run test`
* [ ] Confirm that you see changes to files like `editor/<resource>/<lang code>.json`

### Adding a language

* [ ] Edit `src/supported-locales.js`:
  * [ ] Add entry for the language in the `locales` const
  * [ ] Check if language is right-to-left. If so:
    * Add entry in `rtlLocales`

* [ ] Check if the new language uses a country code
  * Check [https://www.transifex.com/explore/languages](https://www.transifex.com/explore/languages). If the language has a country code:
  * [ ] Edit `src/supported-locales.js`:
    * Add new entry to `localeMap`. Format is `'<W3C HTML browser locale string>': '<Transifex ICU locale string>'`
  * [ ] Edit `.tx/config`:
    * Add to the `lang_map` list. Format is `<Transifex ICU locale string>:<W3C HTML browser locale string>`
    * NOTE: we are moving away from using the `tx` cli; `.tx/config` will eventually be deprecated

* [ ] Edit `src/index.js`:
  * [ ] Add 'import' line
  * [ ] Add entry in `localeData` array

* [ ] Check if locale is in `react-intl`
  * Look in [https://unpkg.com/react-intl/locale-data/](https://unpkg.com/react-intl/locale-data/)
  * If not in `react-intl`:
    * [ ] Edit `src/supported-locales.js`:
      * In `customLocales`, add entry with parent set to a `react-intl` locale
    * [ ] Edit `src/index.js`:
      * In `localeData`, add entry for parent locale

* [ ] Update translations per the "Updating translations" section above
* [ ] Confirm that we see changes to:
    * [ ] `src/supported-locales.js`
    * [ ] `src/index.js`
    * [ ] `.tx/config` (if language needed a new locale)
    * [ ] Multiple files like `editor/<resource>/<lang code>.json`

* [ ] Bump minor version number in `package.json`

* [ ] **Add language po files to scratchr2_translations**
    * manually update `scratchr2_translations/legacy` with `tx pull -l <locale>` and check in changes

* [ ] **Add language to scratchr2 settings**
    * manually update `settings/base.py` with the new language

#### After scratch-l10n update is published:
* [ ] **Update scratch-blocks dependency**
    * [ ] in `package.json`, update the version of the scratch-l10n dependency to the version number you used above
    * [ ] pull translations so that a new `Blockly.ScratchMsgs.locales["<LOCALE CODE>"]` is added to `msg/scratch_msgs.js`
