### PR TITLE
Feature - initialize collection for database blocks

### DIFF
--- a/editor/blocks/en.json
+++ b/editor/blocks/en.json
@@ -566,6 +566,7 @@
     "DATABASE_INSERT_FROM_TABLE": "Insert from table %1 row from %2 to %3 into collection %4",
     "DATABASE_FIND_FROM_COLLECTION":"fetch from collection %1 into table %2 where %3 limit %4 sort by %5 %6 %7 %8",
     "DATABASE_REMOVE_ALL_DOCUMENT":"remove all documents from collection %1 where %2",
+    "DATABASE_INITIALIZE_COLLECTION":"initialize collection",
     "DATABASE_UPDATE_COLLECTION":"update collection %1 from table %2",
     "DATABASE_UPDATE_COLLECTION_IN_PLACE":"update collection %1 in-place where %2 set %3 to %4 set %5 to %6 set %7 to %8 set %9 to %10",
     "RENAME_COLLECTION_TITLE": "Change \"%1\" collection to:",

--- a/editor/blocks/es.json
+++ b/editor/blocks/es.json
@@ -565,6 +565,7 @@
     "DATABASE_INSERT_FROM_TABLE": "Insertar de la tabla %1 fila de %2 a %3 en la colección %4",
     "DATABASE_FIND_FROM_COLLECTION":"recuperar de la colección %1 a la tabla %2 donde %3 limita %4 ordenar por %5 %6 %7 %8",
     "DATABASE_REMOVE_ALL_DOCUMENT":"eliminar todos los documentos de la colección %1 donde %2",
+    "DATABASE_INITIALIZE_COLLECTION":"inicializar colección",
     "DATABASE_UPDATE_COLLECTION":"actualizar la colección %1 de la tabla %2",
     "DATABASE_UPDATE_COLLECTION_IN_PLACE":"actualice la colección %1 en el lugar donde %2 configuró %3 en %4 configuró %5 en %6 configuró %7 en %8 configuró %9 en %10",
     "RENAME_COLLECTION_TITLE": "Cambie la colección \"%1\" a:",

--- a/editor/blocks/fr.json
+++ b/editor/blocks/fr.json
@@ -565,6 +565,7 @@
     "DATABASE_INSERT_FROM_TABLE": "Insérer depuis la table %1 la ligne de %2 à %3 dans la collection %4",
     "DATABASE_FIND_FROM_COLLECTION":"récupérer de la collection %1 dans la table %2 où %3 limite %4 trier par %5 %6 %7 %8",
     "DATABASE_REMOVE_ALL_DOCUMENT":"supprime tous les documents de la collection %1 où %2",
+    "DATABASE_INITIALIZE_COLLECTION":"initialiser la collection",
     "DATABASE_UPDATE_COLLECTION":"mettre à jour la collection %1 à partir de la table %2",
     "DATABASE_UPDATE_COLLECTION_IN_PLACE":"mettre à jour la collection %1 sur place où %2 définir %3 sur %4 définir %5 sur %6 définir %7 sur %8 définir %9 sur %10",
     "RENAME_COLLECTION_TITLE": "Remplacez la collection \"%1\" par :",

--- a/editor/blocks/zh-cn.json
+++ b/editor/blocks/zh-cn.json
@@ -566,6 +566,7 @@
     "DATABASE_INSERT_FROM_TABLE": "从表 %1 行从 %2 到 %3 插入集合 %4",
     "DATABASE_FIND_FROM_COLLECTION":"从集合 %1 提取到表 %2 中，其中 %3 限制 %4 按 %5 %6 %7 %8 排序",
     "DATABASE_REMOVE_ALL_DOCUMENT":"从集合 %1 中删除所有文档，其中 %2",
+    "DATABASE_INITIALIZE_COLLECTION":"初始化集合",
     "DATABASE_UPDATE_COLLECTION":"从表 %2 更新集合 %1",
     "DATABASE_UPDATE_COLLECTION_IN_PLACE":"就地更新集合 %1，其中 %2 将 %3 设置为 %4 将 %5 设置为 %6 将 %7 设置为 %8 将 %9 设置为 %10",
     "RENAME_COLLECTION_TITLE": "将 \"%1\" 集合更改为：",

--- a/editor/blocks/zh-tw.json
+++ b/editor/blocks/zh-tw.json
@@ -548,6 +548,7 @@
     "DATABASE_INSERT_FROM_TABLE": "從表 %1 行從 %2 到 %3 插入集合 %4",
     "DATABASE_FIND_FROM_COLLECTION":"從集合 %1 提取到表 %2 中，其中 %3 限制 %4 按 %5 %6 %7 %8 排序",
     "DATABASE_REMOVE_ALL_DOCUMENT":"從集合 %1 中刪除所有文檔，其中 %2",
+    "DATABASE_INITIALIZE_COLLECTION":"初始化集合",
     "DATABASE_UPDATE_COLLECTION":"從表 %2 更新集合 %1",
     "DATABASE_UPDATE_COLLECTION_IN_PLACE":"就地更新集合 %1，其中 %2 將 %3 設置為 %4 將 %5 設置為 %6 將 %7 設置為 %8 將 %9 設置為 %10",
     "RENAME_COLLECTION_TITLE": "將 \"%1\" 集合更改為：",


### PR DESCRIPTION
**resolve** https://trello.com/c/gez4v7bV/1456-database-collection-issues 

**des** 
when I import a project from my computer, the database seems not initialized properly. The insert and fetch blocks are both causing exceptions. I'm attaching an example project file. I'm guessing when it is a different project, the collection is not defined in the server? Also, this issue might also come up when the user remix a project with database collections? Maybe we need to add a button below "make a collection" named "initialize collection", which will initialize the collection again.

**res**

https://user-images.githubusercontent.com/86275790/179178238-debf3a3e-ea55-41c3-aaec-9774917ade44.mov


