### PR TITLE
feat(premium blocks) non-premium users can play the premium blocks in project home page

### DIFF
--- a/editor/blocks/en.json
+++ b/editor/blocks/en.json
@@ -605,5 +605,6 @@
     "PREDICT_KNN_CLASSIFIER": "predict for table %1 with classifier %2 show neighbors %3",
     "ERROR_DEBUG_TESTING_TABLE_KNN": "Table {tableName} should have the same columns as the table that are used to create the knn classifier",
     "ERROR_DEBUG_TESTING_TABLE_KNN_COL": "The testing table should start with the same columns as the training table",
-    "DATA_SETLISTTOCOLUMN": "set list %1 to column %2 of table %3"
+    "DATA_SETLISTTOCOLUMN": "set list %1 to column %2 of table %3",
+    "PREMIUM_AUTHORIZATION": "The premium blocks in the projects are disabled"
 }

--- a/editor/blocks/es.json
+++ b/editor/blocks/es.json
@@ -603,5 +603,6 @@
     "PREDICT_KNN_CLASSIFIER": "Predecir para la tabla %1 con clasificador %2 con vecinos %3",
     "ERROR_DEBUG_TESTING_TABLE_KNN": "La tabla {tableName} debe tener las mismas columnas que la tabla que se usa para crear el clasificador knn",
     "ERROR_DEBUG_TESTING_TABLE_KNN_COL": "La tabla de prueba debe comenzar con las mismas columnas que la tabla de entrenamiento",
-    "DATA_SETLISTTOCOLUMN": "establecer la lista %1 en la columna %2 de la tabla %3"
+    "DATA_SETLISTTOCOLUMN": "establecer la lista %1 en la columna %2 de la tabla %3",
+    "PREMIUM_AUTHORIZATION": "Los bloques premium en los proyectos están deshabilitados."
 }

--- a/editor/blocks/fr.json
+++ b/editor/blocks/fr.json
@@ -603,5 +603,6 @@
     "PREDICT_KNN_CLASSIFIER": "prévoir pour la table %1 avec le classificateur %2 avec les voisins %3",
     "ERROR_DEBUG_TESTING_TABLE_KNN": "La table {tableName} doit avoir les mêmes colonnes que la table utilisée pour créer le classificateur knn",
     "ERROR_DEBUG_TESTING_TABLE_KNN_COL": "La table de test doit commencer par les mêmes colonnes que la table d'entraînement",
-    "DATA_SETLISTTOCOLUMN": "définir la liste %1 dans la colonne %2 de la table %3"
+    "DATA_SETLISTTOCOLUMN": "définir la liste %1 dans la colonne %2 de la table %3",
+    "PREMIUM_AUTHORIZATION": "Les blocs premium dans les projets sont désactivés"
 }

--- a/editor/blocks/zh-cn.json
+++ b/editor/blocks/zh-cn.json
@@ -604,5 +604,6 @@
     "PREDICT_KNN_CLASSIFIER": "预测表 %1, 分类器为 %2, 邻居为 %3",
     "ERROR_DEBUG_TESTING_TABLE_KNN": "表 {tableName} 应具有与用于创建 knn 分类器的表相同的列",
     "ERROR_DEBUG_TESTING_TABLE_KNN_COL": "测试表应以与训练表相同的列开头",
-    "DATA_SETLISTTOCOLUMN": "将列表 %1 设置为表 %3 的列 %2"
+    "DATA_SETLISTTOCOLUMN": "将列表 %1 设置为表 %3 的列 %2",
+    "PREMIUM_AUTHORIZATION": "项目中的高级块被禁用"
 }

--- a/editor/blocks/zh-tw.json
+++ b/editor/blocks/zh-tw.json
@@ -594,5 +594,6 @@
     "PREDICT_KNN_CLASSIFIER": "預測表 %1, 分類器為 %2, 鄰居為 %3",
     "ERROR_DEBUG_TESTING_TABLE_KNN": "表 {tableName} 應具有與用於創建 knn 分類器的表相同的列",
     "ERROR_DEBUG_TESTING_TABLE_KNN_COL": "測試表應以與訓練表相同的列開頭",
-    "DATA_SETLISTTOCOLUMN": "將列表 %1 設置為表 %3 的列 %2"  
+    "DATA_SETLISTTOCOLUMN": "將列表 %1 設置為表 %3 的列 %2",
+    "PREMIUM_AUTHORIZATION": "項目中的高級塊被禁用"
 }


### PR DESCRIPTION

### Resolves

https://trello.com/c/OMOGxilB/1523-change-some-premium-categories

### Des

For the "3D Effect", and "3D Physics", and "Database" categories, if a user is not a premium user, can we make it so that he can still run a shared/published project at the project home page? But when he look inside or remix, he will not see these premium blocks? 

For example, this project uses 3D Effects. I would like for all users to be able to run it in this page:

https://play.creaticode.com/projects/4688ff4627fcbc5c8f62aa9f?version=1

but when a user looks inside or remixes it, if that user is not premium, then he will not see the 3D effects blocks, so the project will not run anymore. We can show a warning message in the console panel at the bottom to say "The premium blocks in the projects are removed"

note that this will not affect the other premium categories like "AI" or "3D AR". Those won't work even in the project profile page.

### RES 


https://user-images.githubusercontent.com/86275790/188796452-13803947-b26b-4ea2-9d42-768a0f2375d6.mov



