### PR TITLE
enhance(openAI block) Add moderate API to openAI

### DIFF
--- a/editor/blocks/en.json
+++ b/editor/blocks/en.json
@@ -620,5 +620,6 @@
     "ERROR_DEBUG_TESTING_TABLE_KNN": "Table {tableName} should have the same columns as the table that are used to create the knn classifier",
     "ERROR_DEBUG_TESTING_TABLE_KNN_COL": "The testing table should start with the same columns as the training table",
     "DATA_SETLISTTOCOLUMN": "set list %1 to column %2 of table %3",
-    "OPEN_AI_GPT3": "OpenAI GPT-3: request %1 word limit %2"
+    "OPEN_AI_GPT3": "OpenAI GPT-3: request %1 word limit %2",
+    "OPEN_AI_GPT3_WARNING": "The response has been filtered out based on our safety policy"
 }

--- a/editor/blocks/es.json
+++ b/editor/blocks/es.json
@@ -618,5 +618,6 @@
     "ERROR_DEBUG_TESTING_TABLE_KNN": "La tabla {tableName} debe tener las mismas columnas que la tabla que se usa para crear el clasificador knn",
     "ERROR_DEBUG_TESTING_TABLE_KNN_COL": "La tabla de prueba debe comenzar con las mismas columnas que la tabla de entrenamiento",
     "DATA_SETLISTTOCOLUMN": "establecer la lista %1 en la columna %2 de la tabla %3",
-    "OPEN_AI_GPT3": "OpenAI GPT-3: solicitud %1 límite de palabras %2"
+    "OPEN_AI_GPT3": "OpenAI GPT-3: solicitud %1 límite de palabras %2",
+    "OPEN_AI_GPT3_WARNING": "La respuesta ha sido filtrada según nuestra política de seguridad."
 }

--- a/editor/blocks/fr.json
+++ b/editor/blocks/fr.json
@@ -618,5 +618,6 @@
     "ERROR_DEBUG_TESTING_TABLE_KNN": "La table {tableName} doit avoir les mêmes colonnes que la table utilisée pour créer le classificateur knn",
     "ERROR_DEBUG_TESTING_TABLE_KNN_COL": "La table de test doit commencer par les mêmes colonnes que la table d'entraînement",
     "DATA_SETLISTTOCOLUMN": "définir la liste %1 dans la colonne %2 de la table %3",
-    "OPEN_AI_GPT3": "OpenAI GPT-3 : demande %1 limite de mots %2"
+    "OPEN_AI_GPT3": "OpenAI GPT-3 : demande %1 limite de mots %2",
+    "OPEN_AI_GPT3_WARNING": "La réponse a été filtrée en fonction de notre politique de sécurité"
 }

--- a/editor/blocks/zh-cn.json
+++ b/editor/blocks/zh-cn.json
@@ -619,5 +619,6 @@
     "ERROR_DEBUG_TESTING_TABLE_KNN": "表格 {tableName} 应具有与用于创建 knn 分类器的表相同的列",
     "ERROR_DEBUG_TESTING_TABLE_KNN_COL": "测试表应以与训练表相同的列开头",
     "DATA_SETLISTTOCOLUMN": "将列表格 %1 设置为表格 %3 的列 %2",
-    "OPEN_AI_GPT3": "OpenAI GPT-3: 请求 %1 词数限制 %2"
+    "OPEN_AI_GPT3": "OpenAI GPT-3: 请求 %1 词数限制 %2",
+    "OPEN_AI_GPT3_WARNING": "已根据我们的安全政策过滤掉响应"
 }

--- a/editor/blocks/zh-tw.json
+++ b/editor/blocks/zh-tw.json
@@ -609,5 +609,6 @@
     "ERROR_DEBUG_TESTING_TABLE_KNN": "表 {tableName} 應具有與用於創建 knn 分類器的表相同的列",
     "ERROR_DEBUG_TESTING_TABLE_KNN_COL": "測試表應以與訓練表相同的列開頭",
     "DATA_SETLISTTOCOLUMN": "將列表格 %1 設置為表格 %3 的列 %2",
-    "OPEN_AI_GPT3": "OpenAI GPT-3: 請求 %1 詞數限制 %2"
+    "OPEN_AI_GPT3": "OpenAI GPT-3: 請求 %1 詞數限制 %2",
+    "OPEN_AI_GPT3_WARNING": "已根據我們的安全政策過濾掉響應"
 }


### PR DESCRIPTION
### Resolves

https://trello.com/c/t6cURNIv/1628-new-openai-gpt3-block-in-the-ai-category-premium-only

### DES 
we need to use the moderation API to further filter the content before returnning it to the user. If the "flagged" field is true, we should not return the answer from GPT-3, instead, we should return a sentence "The response has been filtered out based on our safety policy".

### RES
<img width="932" alt="Screen Shot 2022-09-29 at 3 24 10 PM" src="https://user-images.githubusercontent.com/86275790/192980018-c8c00e88-a31f-43c3-9aef-17f6c73dd93d.png">


