### PR TITLE
feat(widget category): apply layout block

### DIFF
--- a/editor/extensions/en.json
+++ b/editor/extensions/en.json
@@ -330,6 +330,7 @@
     "widget.runProject-dropdown1": "this",
     "widget.runProject-dropdown2": "new",
     "widget.openNewTabWithURL": "open URL [URL] in new tab",
+    "widget.applyLayoutRowHeightCellWidth": "apply layout row height [HEIGHT]% cell width [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% widgets [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] margin [MARGIN] padding [PADDING]",
     "ai.menuItem.male": "Male",
     "ai.menuItem.female": "Female",
     "ai.menuItem.male2": "Male2",

--- a/editor/extensions/es.json
+++ b/editor/extensions/es.json
@@ -326,6 +326,7 @@
     "widget.runProject-dropdown1": "esto",
     "widget.runProject-dropdown2": "nuevo",
     "widget.openNewTabWithURL": "abrir URL [URL] en una nueva pestaña",
+    "widget.applyLayoutRowHeightCellWidth": "aplicar altura de fila de diseño [HEIGHT]% ancho de celda [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% widgets [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] margen [MARGIN] relleno [PADDING]",
     "normal": "Normal", 
     "left-right flipped": "Volteado de izquierda a derecha",
     "up-down flipped": "Volteado de arriba hacia abajo",

--- a/editor/extensions/fr.json
+++ b/editor/extensions/fr.json
@@ -326,6 +326,7 @@
     "widget.runProject-dropdown1": "ce",
     "widget.runProject-dropdown2": "nouveau",
     "widget.openNewTabWithURL": "ouvrir l'URL [URL] dans un nouvel onglet",
+    "widget.applyLayoutRowHeightCellWidth": "appliquer la hauteur de ligne de mise en page [HEIGHT]% largeur de cellule [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% widgets [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] marge [MARGIN] remplissage [PADDING]",
     "normal": "Normal",
     "gauche-droite retournée": "gauche-droite retournée",
     "haut-bas renversé": "haut-bas renversé",

--- a/editor/extensions/zh-cn.json
+++ b/editor/extensions/zh-cn.json
@@ -332,6 +332,7 @@
     "widget.runProject-dropdown1": "这个",
     "widget.runProject-dropdown2": "新的",
     "widget.openNewTabWithURL": "在新标签页中打开 URL [URL]",
+    "widget.applyLayoutRowHeightCellWidth": "应用布局行高 [HEIGHT]% 单元格宽度 [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% 小部件 [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] 边距 [MARGIN] 填充 [PADDING]",
     "ai.menuItem.male": "男性",
     "ai.menuItem.female": "女性",
     "ai.menuItem.male2": "男性2",

--- a/editor/extensions/zh-tw.json
+++ b/editor/extensions/zh-tw.json
@@ -326,6 +326,7 @@
     "widget.runProject-dropdown1": "這個",
     "widget.runProject-dropdown2": "新的",
     "widget.openNewTabWithURL": "在新選項卡中打開 URL [URL]",
+    "widget.applyLayoutRowHeightCellWidth": "應用佈局行高 [HEIGHT]% 單元格寬度 [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% 小部件 [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] 邊距 [MARGIN] 填充 [PADDING]",
     "normal": "正常", 
     "left-right flipped": "左右翻轉",
     "up-down flipped": "上下翻轉",


### PR DESCRIPTION
### Resolves

https://trello.com/c/SxmMaaQf/1642-new-widget-block-apply-layout
### DES

Currently it is pretty hard to set up the widgets as we need to set the position and size of each widget.

let's add a new stack block to help with layout:

apply layout row height% ( ) cell width% ( ) ( ) ( ) ( ) ( ) ( ) widgets ( ) ( ) ( ) ( ) ( ) ( ) margin ( ) padding

the height% is ratio of the row height vs the stage height (except margin)

the width% is ratio of each widget vs the stage width (except margin)

so if stage width is 480, margin is 10, then the usable width is 460, then if the cell width% is 50 and 50, then each cell is 230 wide. if the padding is 5, then each widget will have width of 230-5-5 = 220

Same for height. if stage height is 360, margin is 10, then usable height is 340. if height% is 20%, then this row's height is 68

if padding is 5, then the widget inside the row will have a height of 68-5-5 = 58.


we run this AFTER we have created the individual widgets

For example, we can do this:
1. create label1

2. create textbox1

3. create button1

4. apply layout row height 20% cell width 30% 50% 20% widgets label1 textbox1 button1 margin 10 padding 5

at step 4, we would ignore the position and size attributes of these 3 widgets, and instead position them based on the layout. 


### RES
<img width="2008" alt="Screen Shot 2022-10-04 at 3 21 02 PM" src="https://user-images.githubusercontent.com/86275790/193770377-ee2535b8-38ed-4620-9eac-b94b91d776ad.png">


