### PR TITLE
feat(widget category): apply row layout block

### DIFF
--- a/editor/extensions/en.json
+++ b/editor/extensions/en.json
@@ -331,7 +331,7 @@
     "widget.runProject-dropdown1": "this",
     "widget.runProject-dropdown2": "new",
     "widget.openNewTabWithURL": "open URL [URL] in new tab",
-    "widget.applyLayoutRowHeightCellWidth": "apply layout row height [HEIGHT]% cell width [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% widgets [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] margin [MARGIN] padding [PADDING]",
+    "widget.applyLayoutRowHeightCellWidth": "apply layout row named [ROW] height [HEIGHT]% cell width [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% widgets [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] margin [MARGIN] padding [PADDING]",
     "ai.menuItem.male": "Male",
     "ai.menuItem.female": "Female",
     "ai.menuItem.male2": "Male2",

--- a/editor/extensions/es.json
+++ b/editor/extensions/es.json
@@ -327,7 +327,7 @@
     "widget.runProject-dropdown1": "esto",
     "widget.runProject-dropdown2": "nuevo",
     "widget.openNewTabWithURL": "abrir URL [URL] en una nueva pestaña",
-    "widget.applyLayoutRowHeightCellWidth": "aplicar altura de fila de diseño [HEIGHT]% ancho de celda [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% widgets [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] margen [MARGIN] relleno [PADDING]",
+    "widget.applyLayoutRowHeightCellWidth": "aplicar fila de diseño llamada [ROW] altura [HEIGHT]% ancho de celda [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% widgets [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] margen [MARGIN] relleno [PADDING]",
     "normal": "Normal", 
     "left-right flipped": "Volteado de izquierda a derecha",
     "up-down flipped": "Volteado de arriba hacia abajo",

--- a/editor/extensions/fr.json
+++ b/editor/extensions/fr.json
@@ -327,7 +327,7 @@
     "widget.runProject-dropdown1": "ce",
     "widget.runProject-dropdown2": "nouveau",
     "widget.openNewTabWithURL": "ouvrir l'URL [URL] dans un nouvel onglet",
-    "widget.applyLayoutRowHeightCellWidth": "appliquer la hauteur de ligne de mise en page [HEIGHT]% largeur de cellule [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% widgets [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] marge [MARGIN] remplissage [PADDING]",
+    "widget.applyLayoutRowHeightCellWidth": "appliquer la ligne de mise en page nommée [ROW] hauteur [HEIGHT]% largeur de cellule [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% widgets [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] marge [MARGIN] remplissage [PADDING]",
     "normal": "Normal",
     "gauche-droite retournée": "gauche-droite retournée",
     "haut-bas renversé": "haut-bas renversé",

--- a/editor/extensions/zh-cn.json
+++ b/editor/extensions/zh-cn.json
@@ -333,7 +333,7 @@
     "widget.runProject-dropdown1": "这个",
     "widget.runProject-dropdown2": "新的",
     "widget.openNewTabWithURL": "在新标签页中打开 URL [URL]",
-    "widget.applyLayoutRowHeightCellWidth": "应用布局行高 [HEIGHT]% 单元格宽度 [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% 小部件 [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] 边距 [MARGIN] 填充 [PADDING]",
+    "widget.applyLayoutRowHeightCellWidth": "应用名为 [ROW] 的布局行高度 [HEIGHT]% 单元格宽度 [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% 小部件 [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] 边距 [MARGIN] 填充 [PADDING]",
     "ai.menuItem.male": "男性",
     "ai.menuItem.female": "女性",
     "ai.menuItem.male2": "男性2",

--- a/editor/extensions/zh-tw.json
+++ b/editor/extensions/zh-tw.json
@@ -327,7 +327,7 @@
     "widget.runProject-dropdown1": "這個",
     "widget.runProject-dropdown2": "新的",
     "widget.openNewTabWithURL": "在新選項卡中打開 URL [URL]",
-    "widget.applyLayoutRowHeightCellWidth": "應用佈局行高 [HEIGHT]% 單元格寬度 [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% 小部件 [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] 邊距 [MARGIN] 填充 [PADDING]",
+    "widget.applyLayoutRowHeightCellWidth": "應用名為 [ROW] 的佈局行高度 [HEIGHT]% 單元格寬度 [WIDTH1]% [WIDTH2]% [WIDTH3]% [WIDTH4]% [WIDTH5]% [WIDTH6]% 小部件 [NAME1] [NAME2] [NAME3] [NAME4] [NAME5] [NAME6] 邊距 [MARGIN] 填充 [PADDING]",
     "normal": "正常", 
     "left-right flipped": "左右翻轉",
     "up-down flipped": "上下翻轉",


### PR DESCRIPTION
### Resolves

https://trello.com/c/pk8a0wUJ/1651-widget-category-apply-layout-does-not-seem-to-work

### DES
we need the row to appear in the top 20% of the window and then stack down. That way, when I use 2 other blocks "apply layout row height 30" and "apply layout row height 50", they will add the 2 new rows below to fill in the rest of the height. Thanks 

height is 20% of total window height from 0% to 20% so appear at the top of the window. That way, we can add another row, say with height 30%, then it will go from 20% to 50% of the window height, below the previous row
### RES


https://user-images.githubusercontent.com/86275790/194533230-2b1ec104-a0c2-439e-bc3b-6ba9c9356e8c.mov

