### PR TITLE
enhance(cloud category): send sms block

### DIFF
--- a/editor/extensions/en.json
+++ b/editor/extensions/en.json
@@ -256,6 +256,7 @@
     "p2p.addToEmailContent": "add to email [NAME] content [TEXT] format [FORMAT] color [COLOR] new line [YES]",
     "p2p.sendEmail": "send email [NAME]",
     "p2p.sendPhoneSMS": "send SMS to receiver phone number [RECEIVER] content [CONTENT] from sender name [SENDERNAME]",
+    "p2p.sendPhoneSMSWarning": "Phone number can only include numbers",
     "p2p.formatContent.normal": "normal",
     "p2p.formatContent.bold": "bold",
     "p2p.formatContent.italic": "italic",

--- a/editor/extensions/es.json
+++ b/editor/extensions/es.json
@@ -255,6 +255,7 @@
     "p2p.addToEmailContent": "agregar al correo electrónico [NAME] contenido [TEXT] formato [FORMAT] color [COLOR] nueva línea [YES]",
     "p2p.sendEmail": "enviar correo electrónico [NAME]",
     "p2p.sendPhoneSMS": "enviar SMS al número de teléfono del receptor [RECEIVER] contenido [CONTENT] desde el nombre del remitente [SENDERNAME]",
+    "p2p.sendPhoneSMSWarning": "El número de teléfono solo puede incluir números",
     "p2p.formatContent.normal": "normal",
     "p2p.formatContent.bold": "negrito",
     "p2p.formatContent.italic": "itálico",

--- a/editor/extensions/fr.json
+++ b/editor/extensions/fr.json
@@ -255,6 +255,7 @@
     "p2p.addToEmailContent": "ajouter à l'e-mail [NAME] contenu [TEXT] format [FORMAT] couleur [COLOR] nouvelle ligne [YES]",
     "p2p.sendEmail": "envoyer un e-mail [NAME]",
     "p2p.sendPhoneSMS": "envoyer un SMS au numéro de téléphone du destinataire [RECEIVER] contenu [CONTENT] du nom de l'expéditeur [SENDERNAME]",
+    "p2p.sendPhoneSMSWarning": "Le numéro de téléphone ne peut contenir que des chiffres",
     "p2p.formatContent.normal": "Ordinaire",
     "p2p.formatContent.bold": "audacieux",
     "p2p.formatContent.italic": "italique",

--- a/editor/extensions/zh-cn.json
+++ b/editor/extensions/zh-cn.json
@@ -259,6 +259,7 @@
     "p2p.addToEmailContent": "添加到电子邮件 [NAME] 内容 [TEXT] 格式 [FORMAT] 颜色 [COLOR] 换行 [YES]",
     "p2p.sendEmail": "发送电子邮件 [NAME]",
     "p2p.sendPhoneSMS": "从发件人姓名 [SENDERNAME] 向收件人电话号码 [RECEIVER] 发送 SMS 内容 [CONTENT]",
+    "p2p.sendPhoneSMSWarning": "电话号码只能包含数字",
     "p2p.formatContent.normal": "普通的",
     "p2p.formatContent.bold": "大胆的",
     "p2p.formatContent.italic": "斜体",

--- a/editor/extensions/zh-tw.json
+++ b/editor/extensions/zh-tw.json
@@ -255,6 +255,7 @@
     "p2p.addToEmailContent": "添加到電子郵件 [NAME] 內容 [TEXT] 格式 [FORMAT] 顏色 [COLOR] 換行 [YES]",
     "p2p.sendEmail": "發送電子郵件 [NAME]",
     "p2p.sendPhoneSMS": "從發件人姓名 [SENDERNAME] 向收件人電話號碼 [RECEIVER] 發送 SMS 內容 [CONTENT]",
+    "p2p.sendPhoneSMSWarning": "電話號碼只能包含數字",
     "p2p.formatContent.normal": "普通的",
     "p2p.formatContent.bold": "大膽的",
     "p2p.formatContent.italic": "斜體",


### PR DESCRIPTION
### Resolves

https://trello.com/c/Th71quy2/1650-cloud-category-send-sms-does-not-work
### DES

the phone number format is "+15166608198". Can you please make 2 new changes? 1. let's add the "+" automatically, so the user only needs to input the numbers. if the phone number only has 10 digits, then we add "+1" at beginning to default to usa. 2. if the phone number has any non-digits, show a warning in the console panel below "Phone number can only include numbers". thanks
