### PR TITLE
fix: add widget menu for release focus block

### DIFF
--- a/editor/extensions/en.json
+++ b/editor/extensions/en.json
@@ -382,7 +382,7 @@
     "widget.addMenuItem": "add menu item [MENUITEM] to menu group named [NAME]",
     "widget.confirmTextWithButtons": "confirm [NAME] with buttons [BUTTON1] [BUTTON2] [BUTTON3] [BUTTON4] [BUTTON5] [BUTTON6]",
     "widget.whenAnyButtonNamedClicked": "when any button named [VARIABLE] clicked",
-    "widget.releaseFocus": "release focus",
+    "widget.releaseFocus": "release focus for widget [WIDGETNAME]",
     "widget.setValueOfWidgetTo": "set value of widget [WIDGET] to [VALUE]",
     "widget.addRadioButton": "add radio buttons [RADIO1] [RADIO2] [RADIO3] [RADIO4] [RADIO5] [RADIO6] [DIRECTION] at x [X] y [Y] width [WIDTH] height [HEIGHT] named [NAME]",
     "widget.addCheckbox": "add checkbox at X [X] Y [Y] named [NAME]",

--- a/editor/extensions/es.json
+++ b/editor/extensions/es.json
@@ -376,7 +376,7 @@
     "widget.addMenuItem": "agregue el elemento de menú [MENUITEM] al grupo de menú llamado [NAME]",
     "widget.confirmTextWithButtons": "confirme [NAME] con los botones [BUTTON1] [BUTTON2] [BUTTON3] [BUTTON4] [BUTTON5] [BUTTON6]",
     "widget.whenAnyButtonNamedClicked": "cuando se hace clic en cualquier botón llamado [VARIABLE]",
-    "widget.releaseFocus": "enfoque de liberación",
+    "widget.releaseFocus": "enfoque de liberación para el widget [WIDGETNAME]",
     "widget.setValueOfWidgetTo": "establecer el valor del widget [WIDGET] en [VALUE]",
     "widget.addRadioButton": "agregar botones de opción [RADIO1] [RADIO2] [RADIO3] [RADIO4] [RADIO5] [RADIO6] [DIRECTION] en x [X] y [Y] ancho [WIDTH] alto [HEIGHT] nombrado [NAME]",
     "widget.addCheckbox": "agregar casilla de verificación en x [X] y [Y] llamado [NAME]",

--- a/editor/extensions/fr.json
+++ b/editor/extensions/fr.json
@@ -376,7 +376,7 @@
     "widget.addMenuItem": "ajouter l'élément de menu [MENUITEM] au groupe de menus nommé [NAME]",
     "widget.confirmTextWithButtons": "confirmer [NAME] avec les boutons [BUTTON1] [BUTTON2] [BUTTON3] [BUTTON4] [BUTTON5] [BUTTON6]",
     "widget.whenAnyButtonNamedClicked": "lorsqu'un bouton nommé [VARIABLE] est cliqué",
-    "widget.releaseFocus": "relâcher l'accent",
+    "widget.releaseFocus": "libérer le focus pour le widget [WIDGETNAME]",
     "widget.setValueOfWidgetTo": "définir la valeur du widget [WIDGET] sur [VALUE]",
     "widget.addRadioButton": "ajouter des boutons radio [RADIO1] [RADIO2] [RADIO3] [RADIO4] [RADIO5] [RADIO6] [DIRECTION] à x [X] y [Y] largeur [WIDTH] hauteur [HEIGHT] nommé [NAME]",
     "widget.addCheckbox": "ajouter une case à cocher à x [X] y [Y] nommé [NAME]",

--- a/editor/extensions/zh-cn.json
+++ b/editor/extensions/zh-cn.json
@@ -382,7 +382,7 @@
     "widget.addMenuItem": "将菜单项 [MENUITEM] 添加到名为 [NAME] 的菜单组",
     "widget.confirmTextWithButtons": "使用按钮 [BUTTON1] [BUTTON2] [BUTTON3] [BUTTON4] [BUTTON5] [BUTTON6] 确认 [NAME]",
     "widget.whenAnyButtonNamedClicked": "当单击任何名为 [VARIABLE] 的按钮时",
-    "widget.releaseFocus": "释放焦点",
+    "widget.releaseFocus": "释放小部件 [WIDGETNAME] 的焦点",
     "widget.setValueOfWidgetTo": "将控件 [WIDGET] 的值设置为 [VALUE]",
     "widget.addRadioButton": "添加单选按钮 [RADIO1] [RADIO2] [RADIO3] [RADIO4] [RADIO5] [RADIO6] [DIRECTION] X [X] Y [Y] 宽度 [WIDTH] 高度 [HEIGHT] 命名为 [NAME]",
     "widget.addCheckbox": "添加复选框 X [X] Y [Y] 名为 [NAME]",

--- a/editor/extensions/zh-tw.json
+++ b/editor/extensions/zh-tw.json
@@ -381,7 +381,7 @@
     "widget.addMenuItem": "將菜單項 [MENUITEM] 添加到名為 [NAME] 的菜單組",
     "widget.confirmTextWithButtons": "使用按鈕 [BUTTON1] [BUTTON2] [BUTTON3] [BUTTON4] [BUTTON5] [BUTTON6] 確認 [NAME]",
     "widget.whenAnyButtonNamedClicked": "當單擊任何名為 [VARIABLE] 的按鈕時",
-    "widget.releaseFocus": "釋放焦點",
+    "widget.releaseFocus": "釋放小部件 [WIDGETNAME] 的焦點",
     "widget.setValueOfWidgetTo": "將控件 [WIDGET] 的值設置為 [VALUE]",
     "widget.addRadioButton": "添加單選按鈕 [RADIO1] [RADIO2] [RADIO3] [RADIO4] [RADIO5] [RADIO6] [DIRECTION] X [X] Y [Y] 寬度 [WIDTH] 高度 [HEIGHT] 命名為 [NAME]",
     "widget.addCheckbox": "添加複選框 X [X] Y [Y] 名為 [NAME]",


### PR DESCRIPTION
### Resolves

- Resolves: https://trello.com/c/E3PIWKQl/1996-release-focus-does-not-work-for-multiple-textboxes